### PR TITLE
Fix 3 vulnerable dependencies identified by Prisma Cloud

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/jar-exclude-group/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/jar-exclude-group/pom.xml
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>@log4j2.version@</version>
+			<version>2.13.2</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/jar-with-unpack/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/jar-with-unpack/pom.xml
@@ -61,7 +61,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>@log4j2.version@</version>
+			<version>2.13.2</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/run-exclude/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/run-exclude/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>@log4j2.version@</version>
+			<version>2.13.2</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>


### PR DESCRIPTION
Prisma Cloud has detected new vulnerabilities or dependencies in the scan performed on Sun, 11 Jul 2021 12:50:51 UTC

**This PR includes the fixes for the vulnerabilities discovered below:**
Severity | Dependency File | Package name | CVE | Risk Score | Fix Status | Description
-- | -- | -- | -- | -- | -- | --
high | buildSrc/build.gradle | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-25649](https://nvd.nist.gov/vuln/detail/CVE-2020-25649) | 7.5 | fixed in 2.10.5.1, 2.9.10.7, 2.6.7.4 | 
high | buildSrc/build.gradle | org.springframework_spring-web | [CVE-2020-5398](https://nvd.nist.gov/vuln/detail/CVE-2020-5398) | 7.5 | fixed in 5.2.3, 5.1.13, 5.0.16 | 
medium | buildSrc/build.gradle | org.springframework_spring-web | [CVE-2020-5397](https://nvd.nist.gov/vuln/detail/CVE-2020-5397) | 5.3 | fixed in 5.2.3 | 
low | spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/jar-exclude-group/pom.xml | org.apache.logging.log4j_log4j-api | [CVE-2020-9488](https://nvd.nist.gov/vuln/detail/CVE-2020-9488) | 3.7 | fixed in 2.13.2 | 
low | spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/jar-with-unpack/pom.xml | org.apache.logging.log4j_log4j-api | [CVE-2020-9488](https://nvd.nist.gov/vuln/detail/CVE-2020-9488) | 3.7 | fixed in 2.13.2 | 
low | spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/run-exclude/pom.xml | org.apache.logging.log4j_log4j-api | [CVE-2020-9488](https://nvd.nist.gov/vuln/detail/CVE-2020-9488) | 3.7 | fixed in 2.13.2 | 
