### PR TITLE
Fix 3 vulnerable dependencies identified by Prisma Cloud

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/jar-exclude-group/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/jar-exclude-group/pom.xml
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>@log4j2.version@</version>
+			<version>2.13.2</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/jar-with-unpack/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/jar-with-unpack/pom.xml
@@ -61,7 +61,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>@log4j2.version@</version>
+			<version>2.13.2</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/run-exclude/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/run-exclude/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>@log4j2.version@</version>
+			<version>2.13.2</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>


### PR DESCRIPTION
Prisma Cloud has detected new vulnerabilities or dependencies in the scan performed on Tue, 13 Jul 2021 12:01:30 UTC

**This PR includes the fixes for the vulnerabilities discovered below:**
Severity | Dependency File | Package name | CVE | Risk Score | Fix Status | Description
-- | -- | -- | -- | -- | -- | --
high | buildSrc/build.gradle | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-25649](https://nvd.nist.gov/vuln/detail/CVE-2020-25649) | 7.5 | fixed in 2.10.5.1, 2.9.10.7, 2.6.7.4 | A flaw was found in FasterXML Jackson Databind, where it did not have entity expansion secured properly. This flaw allows vulnerability to XML external entity (XXE) attacks. The highest threat from this vulnerability is data integrity.
high | buildSrc/build.gradle | org.springframework_spring-web | [CVE-2020-5398](https://nvd.nist.gov/vuln/detail/CVE-2020-5398) | 7.5 | fixed in 5.2.3, 5.1.13, 5.0.16 | In Spring Framework, versions 5.2.x prior to 5.2.3, versions 5.1.x prior to 5.1.13, and versions 5.0.x prior to 5.0.16, an application is vulnerable to a reflected file download (RFD) attack when it sets a \"Content-Disposition\" header in the response where the filename attribute is derived from user supplied input.
medium | buildSrc/build.gradle | org.springframework_spring-web | [CVE-2020-5397](https://nvd.nist.gov/vuln/detail/CVE-2020-5397) | 5.3 | fixed in 5.2.3 | Spring Framework, versions 5.2.x prior to 5.2.3 are vulnerable to CSRF attacks through CORS preflight requests that target Spring MVC (spring-webmvc module) or Spring WebFlux (spring-webflux module) endpoints. Only non-authenticated endpoints are vulnerable because preflight requests should not include credentials and therefore requests should fail authentication. However a notable exception to this are Chrome based browsers when using client certificates for authentication since Chrome sends TLS client certificates in CORS preflight requests in violation of spec requirements. No HTTP body can be sent or received as a result of this attack.
low | spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/run-exclude/pom.xml | org.apache.logging.log4j_log4j-api | [CVE-2020-9488](https://nvd.nist.gov/vuln/detail/CVE-2020-9488) | 3.7 | fixed in 2.13.2 | Improper validation of certificate with host mismatch in Apache Log4j SMTP appender. This could allow an SMTPS connection to be intercepted by a man-in-the-middle attack which could leak any log messages sent through that appender.
low | spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/jar-exclude-group/pom.xml | org.apache.logging.log4j_log4j-api | [CVE-2020-9488](https://nvd.nist.gov/vuln/detail/CVE-2020-9488) | 3.7 | fixed in 2.13.2 | Improper validation of certificate with host mismatch in Apache Log4j SMTP appender. This could allow an SMTPS connection to be intercepted by a man-in-the-middle attack which could leak any log messages sent through that appender.
low | spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/jar-with-unpack/pom.xml | org.apache.logging.log4j_log4j-api | [CVE-2020-9488](https://nvd.nist.gov/vuln/detail/CVE-2020-9488) | 3.7 | fixed in 2.13.2 | Improper validation of certificate with host mismatch in Apache Log4j SMTP appender. This could allow an SMTPS connection to be intercepted by a man-in-the-middle attack which could leak any log messages sent through that appender.
